### PR TITLE
Add ARM64 target build

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,10 +9,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build gnu-linux on ubuntu-18.04 and musl on ubuntu latest
-        # os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: Building, ${{ matrix.os }}
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-latest
+            arch: arm64
+          - os: windows-latest
+            arch: amd64
+          - os: macos-latest
+            arch: amd64
+    name: Building, ${{ matrix.os }}-${{ matrix.arch }}
     steps:
       - name: Fix CRLF on Windows
         if: runner.os == 'Windows'
@@ -45,15 +51,16 @@ jobs:
         with:
           path: |
             ~/x-tools
-          key: ${{ runner.os }}-musl-${{ hashFiles('**/musl-toolchain/preset.sh') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-musl-${{ hashFiles('**/musl-toolchain/preset.sh') }}
           restore-keys: |
-            ${{ runner.os }}-musl-
+            ${{ runner.os }}-${{ matrix.arch }}-musl-
 
-      - name: Build on Linux
-        if: runner.os == 'Linux'
+      - name: Build on Linux x86_64
+        if: runner.os == 'Linux' && matrix.arch == 'amd64'
         # We're using musl to make the binaries statically linked and portable
         run: |
           # Run build script for musl toolchain
+          export CTNG_PRESET=x86_64-multilib-linux-musl
           source musl-toolchain/build.sh
           
           # Go back to the workspace
@@ -67,6 +74,25 @@ jobs:
           cp target/x86_64-unknown-linux-musl/release/kaspa-wallet bin/
           archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-amd64.zip"
           asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-amd64.zip"
+          zip -r "${archive}" ./bin/*
+          echo "archive=${archive}" >> $GITHUB_ENV
+          echo "asset_name=${asset_name}" >> $GITHUB_ENV
+
+      - name: Build on Linux ARM64
+        if: runner.os == 'Linux' && matrix.arch == 'arm64'
+        run: |
+          export CTNG_PRESET=aarch64-linux-musl
+          source musl-toolchain/build.sh
+
+          cd $GITHUB_WORKSPACE
+
+          cargo --verbose build --bin kaspad --bin rothschild --bin kaspa-wallet --release --target aarch64-unknown-linux-musl
+          mkdir bin || true
+          cp target/aarch64-unknown-linux-musl/release/kaspad bin/
+          cp target/aarch64-unknown-linux-musl/release/rothschild bin/
+          cp target/aarch64-unknown-linux-musl/release/kaspa-wallet bin/
+          archive="bin/rusty-kaspa-${{ github.event.release.tag_name }}-linux-arm64.zip"
+          asset_name="rusty-kaspa-${{ github.event.release.tag_name }}-linux-arm64.zip"
           zip -r "${archive}" ./bin/*
           echo "archive=${archive}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV

--- a/musl-toolchain/build.sh
+++ b/musl-toolchain/build.sh
@@ -63,28 +63,40 @@ fi
 export CC=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-gcc
 export CXX=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-g++
 export LD=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-ld
-export AR=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-ar     
+export AR=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-ar
+
+if [ "$CTNG_PRESET" = "x86_64-multilib-linux-musl" ]; then
+  RUST_TARGET="x86_64-unknown-linux-musl"
+elif [ "$CTNG_PRESET" = "aarch64-linux-musl" ]; then
+  RUST_TARGET="aarch64-unknown-linux-musl"
+else
+  echo "Unsupported CTNG_PRESET: $CTNG_PRESET"
+  exit 1
+fi
+
+TARGET_UNDERSCORE=${RUST_TARGET//-/_}
+TARGET_UPPER=${TARGET_UNDERSCORE^^}
 
 # Exports for cc crate
 # https://docs.rs/cc/latest/cc/#external-configuration-via-environment-variables
-export RANLIB_x86_64_unknown_linux_musl=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-ranlib     
-export CC_x86_64_unknown_linux_musl=$CC
-export CXX_x86_64_unknown_linux_musl=$CXX
-export AR_x86_64_unknown_linux_musl=$AR
-export LD_x86_64_unknown_linux_musl=$LD
+export RANLIB_${TARGET_UNDERSCORE}=$HOME/x-tools/$CTNG_PRESET/bin/$CTNG_PRESET-ranlib
+export CC_${TARGET_UNDERSCORE}=$CC
+export CXX_${TARGET_UNDERSCORE}=$CXX
+export AR_${TARGET_UNDERSCORE}=$AR
+export LD_${TARGET_UNDERSCORE}=$LD
 
 # Set environment variables for static linking
 export OPENSSL_STATIC=true
 export RUSTFLAGS="-C link-arg=-static"
 
 # We specify the compiler that will invoke linker
-export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=$CC
+export CARGO_TARGET_${TARGET_UPPER}_LINKER=$CC
 
 # Add target
-rustup target add x86_64-unknown-linux-musl
+rustup target add $RUST_TARGET
 
 # Install missing dependencies
-cargo fetch --target x86_64-unknown-linux-musl
+cargo fetch --target $RUST_TARGET
 
 # Patch missing include in librocksdb-sys-0.16.0+8.10.0. Credit: @supertypo
 FILE_PATH=$(find $HOME/.cargo/registry/src/ -path "*/librocksdb-sys-0.16.0+8.10.0/*/offpeak_time_info.h")

--- a/musl-toolchain/preset.sh
+++ b/musl-toolchain/preset.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Sets the preset that will be used by crosstool-ng
 # Available presets can be fetched with: ct-ng list-samples
-export CTNG_PRESET="x86_64-multilib-linux-musl"
+export CTNG_PRESET="${CTNG_PRESET:-x86_64-multilib-linux-musl}"


### PR DESCRIPTION
## Summary
- support overriding preset for musl toolchain
- generalize build script for x86_64 and aarch64
- produce linux-arm64 binaries in deploy workflow

## Testing
- `cargo --version`
- `cargo check` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6883acbfb3bc832ca226a80ba9b6c35b